### PR TITLE
zlux plugin install changes and env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 This repository stores artifacts relating to the deployment of Zowe on container technologies and cloud platforms.
 
-Please note, the ZLUX App Server (Web Desktop) functionality started when using Docker Compose is currently in development and will not connect to ZSS without manual intervention. This will be documented further soon.
-
 ## Docker Compose (Quickstart)
 
 To start a Zowe environment locally, you can use Docker Compose. This will use the configuration in the `docker-compose.yml` file to start the environment.
@@ -18,14 +16,19 @@ To configure the connection to z/OS, you must specify your z/OSMF endpoint in `d
 
 To do this, open `docker/apiml/api-defs/ibm-zosmf.yml`, and change the value for `services.instanceBaseUrls` to your z/OSMF endpoint.
 
+### Configure zss endpoint
+
+To configure the connection to zss, modify file `docker-compose.yml`.
+In section `zlux-app-server` change values for `environment.ZWED_agent_host` and `environment.ZWED_agent_http_port` to configure zss host and port respectively.
+
 ### Starting Docker Compose environment
 
 Once you have configured the z/OSMF endpoint, and you can issue the following command to start your environment:
-```bash
+```
 docker-compose up
 ```
 
-Once started, you can access the API ML Gateway service at https://localhost:10010/ and the API ML Discovery Service (Eureka dashboard) at https://localhost:10011/
+Once started, you can access the API ML Gateway service at https://localhost:10010/, the API ML Discovery Service (Eureka dashboard) at https://localhost:10011/, and ZOWE Desktop at https://localhost:8544/
 
 ## Kubernetes
 

--- a/build/zlux/Dockerfile.zlux
+++ b/build/zlux/Dockerfile.zlux
@@ -11,7 +11,18 @@
 #########################################################################################
 FROM node:12
 
+ENV ZWE_REFERRER_HOSTS='localhost'
+ENV ZWED_agent_http_ipAddresses=127.0.0.1
+ENV ZWED_agent_host=zss.mymainframe.com
+ENV ZWED_agent_http_port=8542
+ENV ZWED_dataserviceAuthentication_defaultAuthentication=zss
+ENV ZOWE_ZLUX_TELNET_PORT=23
+ENV ZOWE_ZLUX_SECURITY_TYPE=telnet
+
 ADD files/zlux-core-1.17.0.tar /app/zlux-core
+ADD pluginInstall.sh /app/zlux-core/zlux-app-server/bin
+
 WORKDIR /app/zlux-core/zlux-app-server/bin
+RUN mkdir -p /dropins/bin && cp /app/zlux-core/zlux-app-server/bin/install-app.sh /dropins/bin && ./pluginInstall.sh
 
 CMD [ "./app-server.sh" ]

--- a/build/zlux/pluginExtractor.sh
+++ b/build/zlux/pluginExtractor.sh
@@ -16,3 +16,9 @@ DROPINS_DIRECTORY="/dropins"
 DIRECTORY_NAME=$DROPINS_DIRECTORY/$(basename "$1" | cut -d. -f1)
 mkdir -p $DIRECTORY_NAME
 tar -xvf $1 -C $DIRECTORY_NAME
+cd $DIRECTORY_NAME
+if test -f "/dropins/bin/install-app.sh"; then
+  if test -f "pluginDefinition.json"; then
+    /dropins/bin/install-app.sh $DIRECTORY_NAME
+  fi
+fi

--- a/build/zlux/pluginInstall.sh
+++ b/build/zlux/pluginInstall.sh
@@ -1,0 +1,17 @@
+if [ -d "/dropins" ]; then
+  cd /dropins;
+  for D in */;
+   do
+    cd /dropins
+    plugin_base="$D""opt/zowe/plugins/app-server" 
+    if test -d "$plugin_base"; then
+      cd $plugin_base
+      for P in */;
+       do
+        if test -f "$P/pluginDefinition.json"; then
+          /app/zlux-core/zlux-app-server/bin/install-app.sh $P
+        fi
+      done
+    fi
+  done
+fi

--- a/build/zlux/pluginInstall.sh
+++ b/build/zlux/pluginInstall.sh
@@ -1,3 +1,17 @@
+#!/bin/sh
+
+#########################################################################################
+#                                                                                       #
+# This program and the accompanying materials are made available under the terms of the #
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at  #
+# https://www.eclipse.org/legal/epl-v20.html                                            #
+#                                                                                       #
+# SPDX-License-Identifier: EPL-2.0                                                      #
+#                                                                                       #
+# Copyright IBM Corporation 2020                                                        #
+#                                                                                       #
+#########################################################################################
+
 if [ -d "/dropins" ]; then
   cd /dropins;
   for D in */;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,9 @@ services:
             - ./certificates/truststore.p12:/app/tls/mounted-truststore/truststore.p12
             - ./certificates/ca/ca.crt:/app/tls/mounted-keystore/ca.crt
     zlux-app-server:
+        environment: 
+            ZWED_agent_host: zss.mymainframe.com
+            ZWED_agent_http_port: 8542
         restart: "no" #always
         hostname: zlux-app-server
         build:


### PR DESCRIPTION
ZLUX can install plugin if already available - using pluginInstall.sh
Plugin can install themselves if ZLUX already installed - at end of pluginExtractor.sh
Help add plugins and zlux in any order.

Environment variable help setup zss agent for zlux and configure server.json

Need to debug - did not change default for terminal
ENV ZOWE_ZLUX_TELNET_PORT=998
ENV ZOWE_ZLUX_SECURITY_TYPE=tls
But works on manual change


Signed-off-by: Nakul Manchanda <nakul.manchanda@ibm.com>